### PR TITLE
Usa novo nome da action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action accepts the following configuration parameters via `with:`
 ```yaml
 steps:
   - name: Static code analysis step
-    uses: betrybe/linter-evaluator-action
+    uses: betrybe/eslint-linter-action
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -76,7 +76,7 @@ See the [versioning documentation](https://github.com/actions/toolkit/blob/maste
 You can now consume the action by referencing the v1 branch
 
 ```yaml
-uses: betrybe/linter-evaluator-action@v1
+uses: betrybe/eslint-linter-action@v1
 ```
 
-See the [actions tab](https://github.com/betrybe/linter-evaluator-action/actions) for runs of this action! :rocket:
+See the [actions tab](https://github.com/betrybe/eslint-linter-action/actions) for runs of this action! :rocket:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "linter-evaluator-action",
+  "name": "eslint-linter-action",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "linter-evaluator-action",
+  "name": "eslint-linter-action",
   "version": "1.0.0",
   "description": "JavaScript Linter Action",
   "main": "index.js",
@@ -9,15 +9,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/betrybe/linter-evaluator-action.git"
+    "url": "git+https://github.com/betrybe/eslint-linter-action.git"
   },
   "keywords": [],
   "author": "Trybe",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/betrybe/linter-evaluator-action/issues"
+    "url": "https://github.com/betrybe/eslint-linter-action/issues"
   },
-  "homepage": "https://github.com/betrybe/linter-evaluator-action#readme",
+  "homepage": "https://github.com/betrybe/eslint-linter-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.4",
     "@actions/github": "^4.0.0"


### PR DESCRIPTION
Este PR renomeia a action, para assim permitir a criação de múltiplas actions de linters na nossa organização, seguindo o padrão: `<nome-do-linter>-linter-action`

OBS: O nome da action já foi mudado.