### PR TITLE
Adiciona listagem de avisos

### DIFF
--- a/__tests__/feedbackMessage.test.js
+++ b/__tests__/feedbackMessage.test.js
@@ -7,11 +7,17 @@ const multipleErrorsMultipleFiles = require('./fixtures/eslint-results/multipleE
 describe('Feedback message', () => {
   describe('No error is found', () => {
     test('When there is no file to be evaluated, a no error encountered message is returned', () => {
-      expect(buildFeedbackMessage([], './')).toBe('### Nenhum erro encontrado.')
+      expect(buildFeedbackMessage([], './')).toBe(
+        '### Nenhum erro encontrado.\n' +
+        '### Nenhum aviso encontrado.'
+      )
     });
 
     test('When there are files to be evaluated, a no error encountered message is returned', () => {
-      expect(buildFeedbackMessage(noError, './')).toBe('### Nenhum erro encontrado.')
+      expect(buildFeedbackMessage(noError, './')).toBe(
+        '### Nenhum erro encontrado.\n' +
+        '### Nenhum aviso encontrado.'
+      )
     });
   });
 
@@ -21,7 +27,9 @@ describe('Feedback message', () => {
       '\n' +
       '#### Arquivo `/my-project/index.js`\n' +
       '\n' +
-      '- Linha **1**: Function \'isPentagon\' has too many parameters (5). Maximum allowed is 4.\n'
+      '- Linha **1**: Function \'isPentagon\' has too many parameters (5). Maximum allowed is 4.\n' +
+      '\n' +
+      '### Nenhum aviso encontrado.'
     );
   });
 
@@ -35,7 +43,9 @@ describe('Feedback message', () => {
         '- Linha **3**: \'name\' is missing in props validation\n' +
         '- Linha **3**: `Hello, ` must be placed on a new line\n' +
         '- Linha **3**: `{name}` must be placed on a new line\n' +
-        '- Linha **5**: Missing semicolon.\n'
+        '- Linha **5**: Missing semicolon.\n' +
+        '\n' +
+        '### Nenhum aviso encontrado.'
       );
     });
 
@@ -51,7 +61,9 @@ describe('Feedback message', () => {
         '' +
         '#### Arquivo `/my-react-project/src/components/Greeting.js`\n' +
         '\n' +
-        '- Linha **3**: \'name\' is missing in props validation\n'
+        '- Linha **3**: \'name\' is missing in props validation\n' +
+        '\n' +
+        '### Nenhum aviso encontrado.'
       );
     });
   });
@@ -68,7 +80,9 @@ describe('Feedback message', () => {
       '' +
       '#### Arquivo `/src/components/Greeting.js`\n' +
       '\n' +
-      '- Linha **3**: \'name\' is missing in props validation\n'
+      '- Linha **3**: \'name\' is missing in props validation\n' +
+      '\n' +
+      '### Nenhum aviso encontrado.'
     );
   });
 });

--- a/__tests__/feedbackMessage.test.js
+++ b/__tests__/feedbackMessage.test.js
@@ -1,19 +1,24 @@
 const buildFeedbackMessage = require('../feedbackMessage');
+const multipleErrorsOneFile = require('./fixtures/eslint-results/multipleErrorsOneFile.json');
+const multipleWarningsOneFile = require('./fixtures/eslint-results/multipleWarningsOneFile.json');
+const multipleWarningsAndErrorsOneFile = require('./fixtures/eslint-results/multipleWarningsAndErrorsOneFile.json');
+const multipleErrorsMultipleFiles = require('./fixtures/eslint-results/multipleErrorsMultipleFiles.json');
+const multipleWarningsMultipleFiles = require('./fixtures/eslint-results/multipleWarningsMultipleFiles.json');
 const noError = require('./fixtures/eslint-results/frontEndNoError.json');
 const oneError = require('./fixtures/eslint-results/oneError.json');
-const multipleErrorsOneFile = require('./fixtures/eslint-results/multipleErrorsOneFile.json');
-const multipleErrorsMultipleFiles = require('./fixtures/eslint-results/multipleErrorsMultipleFiles.json');
+const oneErrorOneFileMultipleWarningsAnotherFile = require('./fixtures/eslint-results/oneErrorOneFileMultipleWarningsAnotherFile.json');
+const oneWarning = require('./fixtures/eslint-results/oneWarning.json');
 
 describe('Feedback message', () => {
-  describe('No error is found', () => {
-    test('When there is no file to be evaluated, a no error encountered message is returned', () => {
+  describe('No issue is found', () => {
+    test('When there is no file to be evaluated, a no issue encountered message is returned', () => {
       expect(buildFeedbackMessage([], './')).toBe(
         '### Nenhum erro encontrado.\n' +
         '### Nenhum aviso encontrado.'
       )
     });
 
-    test('When there are files to be evaluated, a no error encountered message is returned', () => {
+    test('When there are files to be evaluated, a no issue encountered message is returned', () => {
       expect(buildFeedbackMessage(noError, './')).toBe(
         '### Nenhum erro encontrado.\n' +
         '### Nenhum aviso encontrado.'
@@ -64,6 +69,83 @@ describe('Feedback message', () => {
         '- Linha **3**: \'name\' is missing in props validation\n' +
         '\n' +
         '### Nenhum aviso encontrado.'
+      );
+    });
+  });
+
+  test('When one warning is found, a message showing the warning is returned', () => {
+    expect(buildFeedbackMessage(oneWarning, './')).toBe(
+      '### Nenhum erro encontrado.\n' +
+      '### Foi encontrado 1 aviso.\n' +
+      '\n' +
+      '#### Arquivo `/back-end/index.js`\n' +
+      '\n' +
+      '- Linha **8**: Unexpected console statement.\n'
+    );
+  });
+
+  describe('Multiple warnings are found', () => {
+    test('When all warnings are contained in one file, a message listing all those warnings is returned', () => {
+      expect(buildFeedbackMessage(multipleWarningsOneFile, './')).toBe(
+        '### Nenhum erro encontrado.\n' +
+        '### Foram encontrados 2 avisos.\n' +
+        '\n' +
+        '#### Arquivo `/front-end/src/App.js`\n' +
+        '\n' +
+        '- Linha **7**: Unexpected console statement.\n' +
+        '- Linha **28**: Unexpected alert.\n'
+      );
+    });
+
+    test('When the warnings span multiple files, a message listing all those warnings is returned', () => {
+      expect(buildFeedbackMessage(multipleWarningsMultipleFiles, './')).toBe(
+       '### Nenhum erro encontrado.\n' +
+       '### Foram encontrados 3 avisos.\n' +
+       '\n' +
+       '#### Arquivo `/front-end/src/App.js`\n' +
+       '\n' +
+       '- Linha **7**: Unexpected console statement.\n' +
+       '- Linha **28**: Unexpected alert.\n' +
+       '' +
+       '#### Arquivo `/front-end/src/components/Greeting.js`\n' +
+       '\n' +
+       '- Linha **7**: Missing trailing comma.\n'
+      );
+    });
+  });
+
+  describe('Errors and warnings are found', () => {
+    test('When all errors and warnings are contained in one file, a message listing both errors and warnings is returned', () => {
+      expect(buildFeedbackMessage(multipleWarningsAndErrorsOneFile, './')).toBe(
+        '### Foi encontrado 1 erro.\n' +
+        '\n' +
+        '#### Arquivo `/front-end/src/App.js`\n'+
+        '\n' +
+        '- Linha **33**: Newline required at end of file but not found.\n' +
+        '\n' +
+        '### Foram encontrados 2 avisos.\n' +
+        '\n' +
+        '#### Arquivo `/front-end/src/App.js`\n'+
+        '\n' +
+        '- Linha **7**: Unexpected console statement.\n' +
+        '- Linha **28**: Unexpected alert.\n'
+      );
+    });
+
+    test('When errors are in one file and warnings are in another one, a message listing both errors and warnings for those files is returned', () => {
+      expect(buildFeedbackMessage(oneErrorOneFileMultipleWarningsAnotherFile, './')).toBe(
+        '### Foi encontrado 1 erro.\n' +
+        '\n' +
+        '#### Arquivo `/front-end/src/components/Greeting.js`\n'+
+        '\n' +
+        '- Linha **2**: Missing semicolon.\n' +
+        '\n' +
+        '### Foram encontrados 2 avisos.\n' +
+        '\n' +
+        '#### Arquivo `/front-end/src/App.js`\n'+
+        '\n' +
+        '- Linha **7**: Unexpected console statement.\n' +
+        '- Linha **28**: Unexpected alert.\n'
       );
     });
   });

--- a/__tests__/fixtures/eslint-results/multipleWarningsAndErrorsOneFile.json
+++ b/__tests__/fixtures/eslint-results/multipleWarningsAndErrorsOneFile.json
@@ -1,0 +1,74 @@
+[
+  {
+    "filePath": "/front-end/src/App.js",
+    "messages": [
+      {
+        "ruleId": "no-console",
+        "severity": 1,
+        "message": "Unexpected console statement.",
+        "line": 7,
+        "column": 3,
+        "nodeType": "MemberExpression",
+        "messageId": "unexpected",
+        "endLine": 7,
+        "endColumn": 14
+      },
+      {
+        "ruleId": "no-alert",
+        "severity": 1,
+        "message": "Unexpected alert.",
+        "line": 28,
+        "column": 44,
+        "nodeType": "CallExpression",
+        "messageId": "unexpected",
+        "endLine": 28,
+        "endColumn": 68
+      },
+      {
+        "ruleId": "eol-last",
+        "severity": 2,
+        "message": "Newline required at end of file but not found.",
+        "line": 33,
+        "column": 20,
+        "nodeType": "Program",
+        "messageId": "missing",
+        "fix": {
+          "range": [
+            774,
+            774
+          ],
+          "text": "\n"
+        }
+      }
+    ],
+    "errorCount": 1,
+    "warningCount": 2,
+    "fixableErrorCount": 1,
+    "fixableWarningCount": 0,
+    "source": "import React from 'react';\nimport logo from './logo.svg';\nimport './App.css';\nimport Greeting from './components/Greeting';\n\nfunction App() {\n  console.log('Rendering App..');\n\n  return (\n    <div className=\"App\">\n      <header className=\"App-header\">\n        <img src={logo} className=\"App-logo\" alt=\"logo\" />\n        <p>\n          Edit\n          <code>src/App.js</code>\n          and save to reload.\n        </p>\n        <a\n          className=\"App-link\"\n          href=\"https://reactjs.org\"\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n        >\n          Learn React\n        </a>\n      </header>\n      <Greeting name=\"Alex\" />\n      <button type=\"button\" onClick={() => alert('You clicked me!')}>Click me!</button>\n    </div>\n  );\n}\n\nexport default App;"
+  },
+  {
+    "filePath": "/front-end/src/components/Greeting.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "/front-end/src/index.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "/front-end/src/setupTests.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  }
+]

--- a/__tests__/fixtures/eslint-results/multipleWarningsMultipleFiles.json
+++ b/__tests__/fixtures/eslint-results/multipleWarningsMultipleFiles.json
@@ -1,0 +1,78 @@
+[
+  {
+    "filePath": "/front-end/src/App.js",
+    "messages": [
+      {
+        "ruleId": "no-console",
+        "severity": 1,
+        "message": "Unexpected console statement.",
+        "line": 7,
+        "column": 3,
+        "nodeType": "MemberExpression",
+        "messageId": "unexpected",
+        "endLine": 7,
+        "endColumn": 14
+      },
+      {
+        "ruleId": "no-alert",
+        "severity": 1,
+        "message": "Unexpected alert.",
+        "line": 28,
+        "column": 44,
+        "nodeType": "CallExpression",
+        "messageId": "unexpected",
+        "endLine": 28,
+        "endColumn": 68
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 2,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "import React from 'react';\nimport logo from './logo.svg';\nimport './App.css';\nimport Greeting from './components/Greeting';\n\nfunction App() {\n  console.log('Rendering App..');\n\n  return (\n    <div className=\"App\">\n      <header className=\"App-header\">\n        <img src={logo} className=\"App-logo\" alt=\"logo\" />\n        <p>\n          Edit\n          <code>src/App.js</code>\n          and save to reload.\n        </p>\n        <a\n          className=\"App-link\"\n          href=\"https://reactjs.org\"\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n        >\n          Learn React\n        </a>\n      </header>\n      <Greeting name=\"Alex\" />\n      <button type=\"button\" onClick={() => alert('You clicked me!')}>Click me!</button>\n    </div>\n  );\n}\n\nexport default App;\n"
+  },
+  {
+    "filePath": "/front-end/src/components/Greeting.js",
+    "messages": [
+      {
+        "ruleId": "comma-dangle",
+        "severity": 1,
+        "message": "Missing trailing comma.",
+        "line": 7,
+        "column": 36,
+        "nodeType": "Property",
+        "messageId": "missing",
+        "endLine": 8,
+        "endColumn": 1,
+        "fix": {
+          "range": [
+            183,
+            183
+          ],
+          "text": ","
+        }
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 1,
+    "source": "import React from 'react';\nimport PropTypes from 'prop-types';\n\nconst Greeting = ({ name }) => <h1>{`Hello, ${name}`}</h1>;\n\nGreeting.propTypes = {\n  name: PropTypes.string.isRequired\n};\n\nexport default Greeting;\n"
+  },
+  {
+    "filePath": "/front-end/src/index.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "/front-end/src/setupTests.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  }
+]

--- a/__tests__/fixtures/eslint-results/multipleWarningsOneFile.json
+++ b/__tests__/fixtures/eslint-results/multipleWarningsOneFile.json
@@ -1,0 +1,58 @@
+[
+  {
+    "filePath": "/front-end/src/App.js",
+    "messages": [
+      {
+        "ruleId": "no-console",
+        "severity": 1,
+        "message": "Unexpected console statement.",
+        "line": 7,
+        "column": 3,
+        "nodeType": "MemberExpression",
+        "messageId": "unexpected",
+        "endLine": 7,
+        "endColumn": 14
+      },
+      {
+        "ruleId": "no-alert",
+        "severity": 1,
+        "message": "Unexpected alert.",
+        "line": 28,
+        "column": 44,
+        "nodeType": "CallExpression",
+        "messageId": "unexpected",
+        "endLine": 28,
+        "endColumn": 68
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 2,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "import React from 'react';\nimport logo from './logo.svg';\nimport './App.css';\nimport Greeting from './components/Greeting';\n\nfunction App() {\n  console.log('Rendering App..');\n\n  return (\n    <div className=\"App\">\n      <header className=\"App-header\">\n        <img src={logo} className=\"App-logo\" alt=\"logo\" />\n        <p>\n          Edit\n          <code>src/App.js</code>\n          and save to reload.\n        </p>\n        <a\n          className=\"App-link\"\n          href=\"https://reactjs.org\"\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n        >\n          Learn React\n        </a>\n      </header>\n      <Greeting name=\"Alex\" />\n      <button type=\"button\" onClick={() => alert('You clicked me!')}>Click me!</button>\n    </div>\n  );\n}\n\nexport default App;\n"
+  },
+  {
+    "filePath": "/front-end/src/components/Greeting.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "/front-end/src/index.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "/front-end/src/setupTests.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  }
+]

--- a/__tests__/fixtures/eslint-results/oneErrorOneFileMultipleWarningsAnotherFile.json
+++ b/__tests__/fixtures/eslint-results/oneErrorOneFileMultipleWarningsAnotherFile.json
@@ -1,0 +1,77 @@
+[
+  {
+    "filePath": "/front-end/src/App.js",
+    "messages": [
+      {
+        "ruleId": "no-console",
+        "severity": 1,
+        "message": "Unexpected console statement.",
+        "line": 7,
+        "column": 3,
+        "nodeType": "MemberExpression",
+        "messageId": "unexpected",
+        "endLine": 7,
+        "endColumn": 14
+      },
+      {
+        "ruleId": "no-alert",
+        "severity": 1,
+        "message": "Unexpected alert.",
+        "line": 28,
+        "column": 44,
+        "nodeType": "CallExpression",
+        "messageId": "unexpected",
+        "endLine": 28,
+        "endColumn": 68
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 2,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "import React from 'react';\nimport logo from './logo.svg';\nimport './App.css';\nimport Greeting from './components/Greeting';\n\nfunction App() {\n  console.log('Rendering App..');\n\n  return (\n    <div className=\"App\">\n      <header className=\"App-header\">\n        <img src={logo} className=\"App-logo\" alt=\"logo\" />\n        <p>\n          Edit\n          <code>src/App.js</code>\n          and save to reload.\n        </p>\n        <a\n          className=\"App-link\"\n          href=\"https://reactjs.org\"\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n        >\n          Learn React\n        </a>\n      </header>\n      <Greeting name=\"Alex\" />\n      <button type=\"button\" onClick={() => alert('You clicked me!')}>Click me!</button>\n    </div>\n  );\n}\n\nexport default App;\n"
+  },
+  {
+    "filePath": "/front-end/src/components/Greeting.js",
+    "messages": [
+      {
+        "ruleId": "semi",
+        "severity": 2,
+        "message": "Missing semicolon.",
+        "line": 2,
+        "column": 35,
+        "nodeType": "ImportDeclaration",
+        "endLine": 3,
+        "endColumn": 1,
+        "fix": {
+          "range": [
+            61,
+            61
+          ],
+          "text": ";"
+        }
+      }
+    ],
+    "errorCount": 1,
+    "warningCount": 0,
+    "fixableErrorCount": 1,
+    "fixableWarningCount": 0,
+    "source": "import React from 'react';\nimport PropTypes from 'prop-types'\n\nconst Greeting = ({ name }) => <h1>{`Hello, ${name}`}</h1>;\n\nGreeting.propTypes = {\n  name: PropTypes.string.isRequired,\n};\n\nexport default Greeting;\n"
+  },
+  {
+    "filePath": "/front-end/src/index.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "/front-end/src/setupTests.js",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  }
+]

--- a/__tests__/fixtures/eslint-results/oneWarning.json
+++ b/__tests__/fixtures/eslint-results/oneWarning.json
@@ -1,0 +1,24 @@
+[
+  {
+    "filePath": "/back-end/index.js",
+    "messages": [
+      {
+        "ruleId": "no-console",
+        "severity": 1,
+        "message": "Unexpected console statement.",
+        "line": 8,
+        "column": 5,
+        "nodeType": "MemberExpression",
+        "messageId": "unexpected",
+        "endLine": 8,
+        "endColumn": 16
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "var bar = function (x, y, z, a) {\n    return x + y + z + a;\n}\n\nvar isEven = function (number) {\n    var isNumberOdd = number % 2 === 0;\n\n    console.log('Is number even?', isNumberOdd);\n\n    return isNumberOdd;\n}\n",
+    "usedDeprecatedRules": []
+  }
+]

--- a/dist/index.js
+++ b/dist/index.js
@@ -200,15 +200,15 @@ function onceStrict (fn) {
 /***/ 51:
 /***/ (function(module) {
 
-const countageFieldNameByType = (issueType) => issueType === 'erro' ? 'errorCount' : 'warningCount';
+const countageFieldNameByType = (issueType) => (issueType === 'erro' ? 'errorCount' : 'warningCount');
 
-const issueSeverityToConsider = (issueType) => issueType === 'erro' ? 2 : 1;
+const issueSeverityToConsider = (issueType) => (issueType === 'erro' ? 2 : 1);
 
 const getIssuesCount = (eslintOutcomes, issueType) => {
   const countageToConsider = countageFieldNameByType(issueType);
 
   return eslintOutcomes.reduce((acc, eslintOutcome) => acc + eslintOutcome[countageToConsider], 0);
-}
+};
 
 const buildIssueMessage = ({ line, message }) => `- Linha **${line}**: ${message}`;
 
@@ -218,7 +218,7 @@ const filterMessagesByIssueType = (messages, issueType) => {
   const severityToConsider = issueSeverityToConsider(issueType);
 
   return messages.filter(({ severity }) => severity === severityToConsider);
-}
+};
 
 const buildFileIssues = (eslintOutcomeOnFile, root, issueType) => {
   const countageTypeToConsider = countageFieldNameByType(issueType);
@@ -254,7 +254,7 @@ const buildFeedbackByIssueType = (eslintOutcomes, root, issueType) => {
   }
 
   return feedbackMessage;
-}
+};
 
 const buildFeedbackMessage = (eslintOutcomes, root) => {
   const issueTypes = ['erro', 'aviso'];

--- a/dist/index.js
+++ b/dist/index.js
@@ -200,43 +200,70 @@ function onceStrict (fn) {
 /***/ 51:
 /***/ (function(module) {
 
-const getErrorsCount = (eslintOutcomes) => (
-  eslintOutcomes.reduce((acc, { errorCount }) => acc + errorCount, 0)
-);
+const countageFieldNameByType = (issueType) => issueType === 'erro' ? 'errorCount' : 'warningCount';
 
-const buildErrorMessage = ({ line, message }) => `- Linha **${line}**: ${message}`;
+const issueSeverityToConsider = (issueType) => issueType === 'erro' ? 2 : 1;
+
+const getIssuesCount = (eslintOutcomes, issueType) => {
+  const countageToConsider = countageFieldNameByType(issueType);
+
+  return eslintOutcomes.reduce((acc, eslintOutcome) => acc + eslintOutcome[countageToConsider], 0);
+}
+
+const buildIssueMessage = ({ line, message }) => `- Linha **${line}**: ${message}`;
 
 const buildFileSection = (filePath) => `#### Arquivo \`${filePath}\``;
 
-const buildFileErrors = ({ errorCount, filePath, messages }, root) => {
-  if (errorCount === 0) return '';
+const filterMessagesByIssueType = (messages, issueType) => {
+  const severityToConsider = issueSeverityToConsider(issueType);
 
+  return messages.filter(({ severity }) => severity === severityToConsider);
+}
+
+const buildFileIssues = (eslintOutcomeOnFile, root, issueType) => {
+  const countageTypeToConsider = countageFieldNameByType(issueType);
+  const issuesCount = eslintOutcomeOnFile[countageTypeToConsider];
+
+  if (issuesCount === 0) return '';
+
+  const { filePath, messages } = eslintOutcomeOnFile;
   const relativePathFile = filePath.replace(root, '');
   const fileSection = `${buildFileSection(relativePathFile)}\n\n`;
+  const messagesToConsider = filterMessagesByIssueType(messages, issueType);
 
-  return messages.reduce((acc, error) => `${acc}${buildErrorMessage(error)}\n`, fileSection);
+  return messagesToConsider.reduce((acc, issue) => `${acc}${buildIssueMessage(issue)}\n`, fileSection);
 };
 
-const listErrors = (eslintOutcomes, root) => (
-  eslintOutcomes.reduce((acc, currentFile) => acc + buildFileErrors(currentFile, root), '')
+const listIssues = (eslintOutcomes, root, issueType) => (
+  eslintOutcomes.reduce((acc, currentFile) => acc + buildFileIssues(currentFile, root, issueType), '')
 );
 
-const getSummaryMessage = (eslintOutcomes) => {
-  const errorsCount = getErrorsCount(eslintOutcomes);
+const getSummaryMessage = (eslintOutcomes, issueType) => {
+  const issuesCount = getIssuesCount(eslintOutcomes, issueType);
 
-  if (errorsCount === 0) return '### Nenhum erro encontrado.';
-  if (errorsCount === 1) return '### Foi encontrado 1 erro.';
-  return `### Foram encontrados ${errorsCount} erros.`;
+  if (issuesCount === 0) return `### Nenhum ${issueType} encontrado.`;
+  if (issuesCount === 1) return `### Foi encontrado 1 ${issueType}.`;
+  return `### Foram encontrados ${issuesCount} ${issueType}s.`;
 };
 
-const buildFeedbackMessage = (eslintOutcomes, root) => {
-  let feedbackMessage = getSummaryMessage(eslintOutcomes);
+const buildFeedbackByIssueType = (eslintOutcomes, root, issueType) => {
+  let feedbackMessage = getSummaryMessage(eslintOutcomes, issueType);
 
-  if (feedbackMessage !== '### Nenhum erro encontrado.') {
-    feedbackMessage = `${feedbackMessage}\n\n${listErrors(eslintOutcomes, root)}`;
+  if (feedbackMessage !== `### Nenhum ${issueType} encontrado.`) {
+    feedbackMessage = `${feedbackMessage}\n\n${listIssues(eslintOutcomes, root, issueType)}`;
   }
 
   return feedbackMessage;
+}
+
+const buildFeedbackMessage = (eslintOutcomes, root) => {
+  const issueTypes = ['erro', 'aviso'];
+
+  const feedbackMessages = issueTypes.map(
+    (issueType) => buildFeedbackByIssueType(eslintOutcomes, root, issueType)
+  );
+
+  return feedbackMessages.join('\n');
 };
 
 module.exports = buildFeedbackMessage;

--- a/feedbackMessage.js
+++ b/feedbackMessage.js
@@ -1,12 +1,12 @@
-const countageFieldNameByType = (issueType) => issueType === 'erro' ? 'errorCount' : 'warningCount';
+const countageFieldNameByType = (issueType) => (issueType === 'erro' ? 'errorCount' : 'warningCount');
 
-const issueSeverityToConsider = (issueType) => issueType === 'erro' ? 2 : 1;
+const issueSeverityToConsider = (issueType) => (issueType === 'erro' ? 2 : 1);
 
 const getIssuesCount = (eslintOutcomes, issueType) => {
   const countageToConsider = countageFieldNameByType(issueType);
 
   return eslintOutcomes.reduce((acc, eslintOutcome) => acc + eslintOutcome[countageToConsider], 0);
-}
+};
 
 const buildIssueMessage = ({ line, message }) => `- Linha **${line}**: ${message}`;
 
@@ -16,7 +16,7 @@ const filterMessagesByIssueType = (messages, issueType) => {
   const severityToConsider = issueSeverityToConsider(issueType);
 
   return messages.filter(({ severity }) => severity === severityToConsider);
-}
+};
 
 const buildFileIssues = (eslintOutcomeOnFile, root, issueType) => {
   const countageTypeToConsider = countageFieldNameByType(issueType);
@@ -52,7 +52,7 @@ const buildFeedbackByIssueType = (eslintOutcomes, root, issueType) => {
   }
 
   return feedbackMessage;
-}
+};
 
 const buildFeedbackMessage = (eslintOutcomes, root) => {
   const issueTypes = ['erro', 'aviso'];

--- a/feedbackMessage.js
+++ b/feedbackMessage.js
@@ -1,40 +1,67 @@
-const getErrorsCount = (eslintOutcomes) => (
-  eslintOutcomes.reduce((acc, { errorCount }) => acc + errorCount, 0)
-);
+const countageFieldNameByType = (issueType) => issueType === 'erro' ? 'errorCount' : 'warningCount';
 
-const buildErrorMessage = ({ line, message }) => `- Linha **${line}**: ${message}`;
+const issueSeverityToConsider = (issueType) => issueType === 'erro' ? 2 : 1;
+
+const getIssuesCount = (eslintOutcomes, issueType) => {
+  const countageToConsider = countageFieldNameByType(issueType);
+
+  return eslintOutcomes.reduce((acc, eslintOutcome) => acc + eslintOutcome[countageToConsider], 0);
+}
+
+const buildIssueMessage = ({ line, message }) => `- Linha **${line}**: ${message}`;
 
 const buildFileSection = (filePath) => `#### Arquivo \`${filePath}\``;
 
-const buildFileErrors = ({ errorCount, filePath, messages }, root) => {
-  if (errorCount === 0) return '';
+const filterMessagesByIssueType = (messages, issueType) => {
+  const severityToConsider = issueSeverityToConsider(issueType);
 
+  return messages.filter(({ severity }) => severity === severityToConsider);
+}
+
+const buildFileIssues = (eslintOutcomeOnFile, root, issueType) => {
+  const countageTypeToConsider = countageFieldNameByType(issueType);
+  const issuesCount = eslintOutcomeOnFile[countageTypeToConsider];
+
+  if (issuesCount === 0) return '';
+
+  const { filePath, messages } = eslintOutcomeOnFile;
   const relativePathFile = filePath.replace(root, '');
   const fileSection = `${buildFileSection(relativePathFile)}\n\n`;
+  const messagesToConsider = filterMessagesByIssueType(messages, issueType);
 
-  return messages.reduce((acc, error) => `${acc}${buildErrorMessage(error)}\n`, fileSection);
+  return messagesToConsider.reduce((acc, issue) => `${acc}${buildIssueMessage(issue)}\n`, fileSection);
 };
 
-const listErrors = (eslintOutcomes, root) => (
-  eslintOutcomes.reduce((acc, currentFile) => acc + buildFileErrors(currentFile, root), '')
+const listIssues = (eslintOutcomes, root, issueType) => (
+  eslintOutcomes.reduce((acc, currentFile) => acc + buildFileIssues(currentFile, root, issueType), '')
 );
 
-const getSummaryMessage = (eslintOutcomes) => {
-  const errorsCount = getErrorsCount(eslintOutcomes);
+const getSummaryMessage = (eslintOutcomes, issueType) => {
+  const issuesCount = getIssuesCount(eslintOutcomes, issueType);
 
-  if (errorsCount === 0) return '### Nenhum erro encontrado.';
-  if (errorsCount === 1) return '### Foi encontrado 1 erro.';
-  return `### Foram encontrados ${errorsCount} erros.`;
+  if (issuesCount === 0) return `### Nenhum ${issueType} encontrado.`;
+  if (issuesCount === 1) return `### Foi encontrado 1 ${issueType}.`;
+  return `### Foram encontrados ${issuesCount} ${issueType}s.`;
 };
 
-const buildFeedbackMessage = (eslintOutcomes, root) => {
-  let feedbackMessage = getSummaryMessage(eslintOutcomes);
+const buildFeedbackByIssueType = (eslintOutcomes, root, issueType) => {
+  let feedbackMessage = getSummaryMessage(eslintOutcomes, issueType);
 
-  if (feedbackMessage !== '### Nenhum erro encontrado.') {
-    feedbackMessage = `${feedbackMessage}\n\n${listErrors(eslintOutcomes, root)}`;
+  if (feedbackMessage !== `### Nenhum ${issueType} encontrado.`) {
+    feedbackMessage = `${feedbackMessage}\n\n${listIssues(eslintOutcomes, root, issueType)}`;
   }
 
   return feedbackMessage;
+}
+
+const buildFeedbackMessage = (eslintOutcomes, root) => {
+  const issueTypes = ['erro', 'aviso'];
+
+  const feedbackMessages = issueTypes.map(
+    (issueType) => buildFeedbackByIssueType(eslintOutcomes, root, issueType)
+  );
+
+  return feedbackMessages.join('\n');
 };
 
 module.exports = buildFeedbackMessage;


### PR DESCRIPTION
Este PR adiciona a listagem de avisos no comentário de feedback que é postado no pull request da pessoa estudante. Dessa forma, a mensagem de feedback agora contempla tanto erro quanto aviso que for encontrado pela análise do ESLint.

Pode-se ver o novo comportamento neste [PR de teste](https://github.com/betrybe/linter-evaluator-teste/pull/2#issuecomment-691073565).