### PR TITLE
Adiciona suporte à análise de arquivos .jsx

### DIFF
--- a/__tests__/runEslintWithConfigFile.test.js
+++ b/__tests__/runEslintWithConfigFile.test.js
@@ -16,7 +16,15 @@ describe('Running eslint', () => {
     expect(receivedStatus).toStrictEqual({ status: 0, outcomes: eslintResultWithoutError });
     expect(spawnSync).toHaveBeenCalledWith(
       'npx',
-      ['eslint', '-f', 'json', '--no-inline-config', '--no-error-on-unmatched-pattern', '-c', '.eslintrc.json', '.'],
+      [
+        'eslint',
+        '-f', 'json',
+        '--no-inline-config',
+        '--ext', '.js, .jsx',
+        '--no-error-on-unmatched-pattern',
+        '-c', '.eslintrc.json',
+        '.'
+      ],
       { cwd: packageDirectory },
     );
   });
@@ -33,7 +41,15 @@ describe('Running eslint', () => {
     expect(receivedStatus).toStrictEqual({ status: 0, outcomes: emptyEslintResult });
     expect(spawnSync).toHaveBeenCalledWith(
       'npx',
-      ['eslint', '-f', 'json', '--no-inline-config', '--no-error-on-unmatched-pattern', '-c', '.eslintrc.json', '.'],
+      [
+        'eslint',
+        '-f', 'json',
+        '--no-inline-config',
+        '--ext', '.js, .jsx',
+        '--no-error-on-unmatched-pattern',
+        '-c', '.eslintrc.json',
+        '.'
+      ],
       { cwd: packageDirectory },
     );
   });
@@ -48,7 +64,15 @@ describe('Running eslint', () => {
     expect(receivedStatus).toStrictEqual({ status: 1, outcomes: eslintResultWithError });
     expect(spawnSync).toHaveBeenCalledWith(
       'npx',
-      ['eslint', '-f', 'json', '--no-inline-config', '--no-error-on-unmatched-pattern', '-c', '.eslintrc.json', '.'],
+      [
+        'eslint',
+        '-f', 'json',
+        '--no-inline-config',
+        '--ext', '.js, .jsx',
+        '--no-error-on-unmatched-pattern',
+        '-c', '.eslintrc.json',
+        '.'
+      ],
       { cwd: packageDirectory },
     );
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -4741,7 +4741,15 @@ const runEslintWithConfigFile = (file) => {
 
   const eslintProcess = spawnSync(
     'npx',
-    ['eslint', '-f', 'json', '--no-inline-config', '--no-error-on-unmatched-pattern', '-c', path.basename(file), '.'],
+    [
+      'eslint',
+      '-f', 'json',
+      '--no-inline-config',
+      '--ext', '.js, .jsx',
+      '--no-error-on-unmatched-pattern',
+      '-c', path.basename(file),
+      '.',
+    ],
     { cwd: path.dirname(file) },
   );
   const outcomes = JSON.parse(eslintProcess.stdout);

--- a/runEslintWithConfigFile.js
+++ b/runEslintWithConfigFile.js
@@ -7,7 +7,15 @@ const runEslintWithConfigFile = (file) => {
 
   const eslintProcess = spawnSync(
     'npx',
-    ['eslint', '-f', 'json', '--no-inline-config', '--no-error-on-unmatched-pattern', '-c', path.basename(file), '.'],
+    [
+      'eslint',
+      '-f', 'json',
+      '--no-inline-config',
+      '--ext', '.js, .jsx',
+      '--no-error-on-unmatched-pattern',
+      '-c', path.basename(file),
+      '.',
+    ],
     { cwd: path.dirname(file) },
   );
   const outcomes = JSON.parse(eslintProcess.stdout);


### PR DESCRIPTION
Este PR adiciona suporte a arquivos do tipo `.jsx` na análise do `ESLint`.

Para validar o novo comportamento, foi usada esta nova versão da action nos seguintes PRs:
1. Monorepo, a partir deste [comentário postado pela action](https://github.com/betrybe/linter-evaluator-teste/pull/2#issuecomment-723140589)
1. Projeto de back-end, a partir deste [comentário postado pela action](https://github.com/betrybe/linter-evaluator-teste/pull/1#issuecomment-723157597)