### PR TITLE
Adiciona input ignoreInlineConfig

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,12 @@
+name: 'Tests'
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Basic:
 
 ```yaml
 steps:
-  - uses: actions/setup-node@v1.4.3
+  - uses: actions/setup-node@v1.4.4
     with:
       node-version: '12'
   - name: Static code analysis step
@@ -37,7 +37,7 @@ Allow inline configuration comments:
 
 ```yaml
 steps:
-  - uses: actions/setup-node@v1.4.3
+  - uses: actions/setup-node@v1.4.4
     with:
       node-version: '12'
   - name: Static code analysis step

--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ This action accepts the following configuration parameters via `with:`
 
   **Required**
 
-  The GitHub token to use for making API requests
+  The GitHub token to use for making API requests.
 
-## Example usage
+- `ignoreInlineConfig`
+
+  **Optional**
+
+  Set this option if inline configuration comments should be ignored on the analysis. The default is `true`.
+
+## Usage
+
+Basic:
 
 ```yaml
 steps:
@@ -23,6 +31,20 @@ steps:
     uses: betrybe/eslint-linter-action@v2
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Allow inline configuration comments:
+
+```yaml
+steps:
+  - uses: actions/setup-node@v1.4.3
+    with:
+      node-version: '12'
+  - name: Static code analysis step
+    uses: betrybe/eslint-linter-action@v2
+    with:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      ignoreInlineConfig: false
 ```
 
 Check the latest version to use [here](https://github.com/betrybe/eslint-linter-action/releases).

--- a/__tests__/runEslintWithConfigFile.test.js
+++ b/__tests__/runEslintWithConfigFile.test.js
@@ -10,7 +10,7 @@ const runEslintWithConfigFile = require('../runEslintWithConfigFile');
 describe('Running eslint', () => {
   test('When there is an eslint config file to analyse and the analysis shows no issue, a success status is returned', () => {
     spawnSync.mockReturnValue({ status: 0, stdout: JSON.stringify(eslintResultWithoutError) });
-    getInput.mockReturnValue(true);
+    getInput.mockReturnValue('true');
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -36,7 +36,7 @@ describe('Running eslint', () => {
     const emptyEslintResult = [];
 
     spawnSync.mockReturnValue({ status: 0, stdout: JSON.stringify(emptyEslintResult) });
-    getInput.mockReturnValue(true);
+    getInput.mockReturnValue('true');
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -60,7 +60,7 @@ describe('Running eslint', () => {
 
   test('When there is an eslint config file to analyse and the analysis shows some issue, an error status is returned', () => {
     spawnSync.mockReturnValue({ status: 1, stdout: JSON.stringify(eslintResultWithError) });
-    getInput.mockReturnValue(true);
+    getInput.mockReturnValue('true');
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -83,7 +83,7 @@ describe('Running eslint', () => {
   });
 
   test('When the `ignoreInlineConfig` input is true, eslint is called with the `--no-inline-config` argument', () => {
-    getInput.mockReturnValue(true);
+    getInput.mockReturnValue('true');
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -106,7 +106,7 @@ describe('Running eslint', () => {
   });
 
   test('When the `ignoreInlineConfig` input is false, eslint is called without the `--no-inline-config` argument', () => {
-    getInput.mockReturnValue(false);
+    getInput.mockReturnValue('false');
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;

--- a/__tests__/runEslintWithConfigFile.test.js
+++ b/__tests__/runEslintWithConfigFile.test.js
@@ -1,5 +1,7 @@
+jest.mock('@actions/core');
 jest.mock('child_process');
 
+const { getInput } = require('@actions/core');
 const { spawnSync } = require('child_process');
 const eslintResultWithError = require('./fixtures/eslint-results/oneError.json');
 const eslintResultWithoutError = require('./fixtures/eslint-results/frontEndNoError.json');
@@ -8,6 +10,7 @@ const runEslintWithConfigFile = require('../runEslintWithConfigFile');
 describe('Running eslint', () => {
   test('When there is an eslint config file to analyse and the analysis shows no issue, a success status is returned', () => {
     spawnSync.mockReturnValue({ status: 0, stdout: JSON.stringify(eslintResultWithoutError) });
+    getInput.mockReturnValue(true);
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -33,6 +36,7 @@ describe('Running eslint', () => {
     const emptyEslintResult = [];
 
     spawnSync.mockReturnValue({ status: 0, stdout: JSON.stringify(emptyEslintResult) });
+    getInput.mockReturnValue(true);
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -56,6 +60,7 @@ describe('Running eslint', () => {
 
   test('When there is an eslint config file to analyse and the analysis shows some issue, an error status is returned', () => {
     spawnSync.mockReturnValue({ status: 1, stdout: JSON.stringify(eslintResultWithError) });
+    getInput.mockReturnValue(true);
 
     const packageDirectory = '/path/to/project';
     const packageFile = `${packageDirectory}/.eslintrc.json`;
@@ -68,6 +73,51 @@ describe('Running eslint', () => {
         'eslint',
         '-f', 'json',
         '--no-inline-config',
+        '--ext', '.js, .jsx',
+        '--no-error-on-unmatched-pattern',
+        '-c', '.eslintrc.json',
+        '.'
+      ],
+      { cwd: packageDirectory },
+    );
+  });
+
+  test('When the `ignoreInlineConfig` input is true, eslint is called with the `--no-inline-config` argument', () => {
+    getInput.mockReturnValue(true);
+
+    const packageDirectory = '/path/to/project';
+    const packageFile = `${packageDirectory}/.eslintrc.json`;
+
+    runEslintWithConfigFile(packageFile);
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npx',
+      [
+        'eslint',
+        '-f', 'json',
+        '--no-inline-config',
+        '--ext', '.js, .jsx',
+        '--no-error-on-unmatched-pattern',
+        '-c', '.eslintrc.json',
+        '.'
+      ],
+      { cwd: packageDirectory },
+    );
+  });
+
+  test('When the `ignoreInlineConfig` input is false, eslint is called without the `--no-inline-config` argument', () => {
+    getInput.mockReturnValue(false);
+
+    const packageDirectory = '/path/to/project';
+    const packageFile = `${packageDirectory}/.eslintrc.json`;
+
+    runEslintWithConfigFile(packageFile);
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npx',
+      [
+        'eslint',
+        '-f', 'json',
         '--ext', '.js, .jsx',
         '--no-error-on-unmatched-pattern',
         '-c', '.eslintrc.json',

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: "The GitHub token to use for making API requests"
     required: true
+  ignoreInlineConfig:
+    description: "Whether or not inline configurations should be ignored"
+    default: true
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -4732,6 +4732,7 @@ exports.createTokenAuth = createTokenAuth;
 /***/ 834:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
+const core = __webpack_require__(470);
 const { spawnSync } = __webpack_require__(129);
 const path = __webpack_require__(622);
 const logProcessConclusion = __webpack_require__(234);
@@ -4739,17 +4740,22 @@ const logProcessConclusion = __webpack_require__(234);
 const runEslintWithConfigFile = (file) => {
   console.log('-- found:', file);
 
+  const ignoreInlineConfig = core.getInput('ignoreInlineConfig');
+
+  const args = [
+    'eslint',
+    '-f', 'json',
+    '--ext', '.js, .jsx',
+    '--no-error-on-unmatched-pattern',
+    '-c', path.basename(file),
+    '.',
+  ];
+
+  if (ignoreInlineConfig) args.splice(3, 0, '--no-inline-config');
+
   const eslintProcess = spawnSync(
     'npx',
-    [
-      'eslint',
-      '-f', 'json',
-      '--no-inline-config',
-      '--ext', '.js, .jsx',
-      '--no-error-on-unmatched-pattern',
-      '-c', path.basename(file),
-      '.',
-    ],
+    args,
     { cwd: path.dirname(file) },
   );
   const outcomes = JSON.parse(eslintProcess.stdout);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4740,7 +4740,7 @@ const logProcessConclusion = __webpack_require__(234);
 const runEslintWithConfigFile = (file) => {
   console.log('-- found:', file);
 
-  const ignoreInlineConfig = core.getInput('ignoreInlineConfig');
+  const ignoreInlineConfig = core.getInput('ignoreInlineConfig') == 'true';
 
   const args = [
     'eslint',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "jest": "^26.4.0"
   },
   "jest": {
-    "testPathIgnorePatterns": ["__tests__/fixtures"]
+    "testPathIgnorePatterns": [
+      "__tests__/fixtures"
+    ]
   }
 }

--- a/runEslintWithConfigFile.js
+++ b/runEslintWithConfigFile.js
@@ -6,7 +6,7 @@ const logProcessConclusion = require('./logProcessConclusion');
 const runEslintWithConfigFile = (file) => {
   console.log('-- found:', file);
 
-  const ignoreInlineConfig = core.getInput('ignoreInlineConfig');
+  const ignoreInlineConfig = core.getInput('ignoreInlineConfig') == 'true';
 
   const args = [
     'eslint',

--- a/runEslintWithConfigFile.js
+++ b/runEslintWithConfigFile.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core');
 const { spawnSync } = require('child_process');
 const path = require('path');
 const logProcessConclusion = require('./logProcessConclusion');
@@ -5,17 +6,22 @@ const logProcessConclusion = require('./logProcessConclusion');
 const runEslintWithConfigFile = (file) => {
   console.log('-- found:', file);
 
+  const ignoreInlineConfig = core.getInput('ignoreInlineConfig');
+
+  const args = [
+    'eslint',
+    '-f', 'json',
+    '--ext', '.js, .jsx',
+    '--no-error-on-unmatched-pattern',
+    '-c', path.basename(file),
+    '.',
+  ];
+
+  if (ignoreInlineConfig) args.splice(3, 0, '--no-inline-config');
+
   const eslintProcess = spawnSync(
     'npx',
-    [
-      'eslint',
-      '-f', 'json',
-      '--no-inline-config',
-      '--ext', '.js, .jsx',
-      '--no-error-on-unmatched-pattern',
-      '-c', path.basename(file),
-      '.',
-    ],
+    args,
     { cwd: path.dirname(file) },
   );
   const outcomes = JSON.parse(eslintProcess.stdout);


### PR DESCRIPTION
Este PR adiciona à action o input `ignoreInlineConfig`. A intenção é permitir que nossos projetos internos possam utilizar comentários inline, como `eslint-disable-next-line`, para desabilitar regras quando acharmos necessário sem que o avaliador as ignore e reporte erros.

 Por default, esse input é `true`. Dessa forma, nenhuma alteraçãos no projetos de estudantes será necessária.