### PR TITLE
fix: desconsidera arquivo dentro da pasta .github

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ steps:
     with:
       node-version: '12'
   - name: Static code analysis step
-    uses: betrybe/eslint-linter-action@v2
+    uses: betrybe/eslint-linter-action@v3.2
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
       pr_number: ${{ github.event.inputs.pr_number }}
@@ -80,7 +80,7 @@ steps:
     with:
       node-version: '12'
   - name: Static code analysis step
-    uses: betrybe/eslint-linter-action@v2
+    uses: betrybe/eslint-linter-action@v3.2
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
       pr_number: ${{ github.event.inputs.pr_number }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -131,7 +131,7 @@ const findFilesBy = (startDirectory, stringSearch) => {
     files.forEach((file) => {
       const filename = path.join(currentDirectory, file);
 
-      if (filename.indexOf('node_modules') !== -1) return;
+      if (notNodeModulesDirectory(filename) || isActionDirectory(filename)) return;
 
       const stat = fs.lstatSync(filename);
 
@@ -142,6 +142,10 @@ const findFilesBy = (startDirectory, stringSearch) => {
 
   return foundFiles;
 };
+
+const notNodeModulesDirectory = (filename) => filename.indexOf('node_modules') !== -1;
+
+const isActionDirectory = (filename) => filename.includes('.github/actions');
 
 module.exports = findFilesBy;
 

--- a/findFilesBy.js
+++ b/findFilesBy.js
@@ -22,18 +22,20 @@ const findFilesBy = (startDirectory, stringSearch) => {
     files.forEach((file) => {
       const filename = path.join(currentDirectory, file);
 
-      if (filename.indexOf('node_modules') !== -1) return;
+      if (notNodeModulesDirectory(filename) || isActionDirectory(filename)) return;
 
       const stat = fs.lstatSync(filename);
 
       if (stat.isDirectory()) directories.push(filename);
-      else if (filename.indexOf(stringSearch) >= 0 && notGithubDirectory(filename)) foundFiles.push(filename);
+      else if (filename.indexOf(stringSearch) >= 0) foundFiles.push(filename);
     });
   }
 
   return foundFiles;
 };
 
-const notGithubDirectory = (filename) => !filename.includes('.github/actions');
+const notNodeModulesDirectory = (filename) => filename.indexOf('node_modules') !== -1;
+
+const isActionDirectory = (filename) => filename.includes('.github/actions');
 
 module.exports = findFilesBy;

--- a/findFilesBy.js
+++ b/findFilesBy.js
@@ -27,11 +27,15 @@ const findFilesBy = (startDirectory, stringSearch) => {
       const stat = fs.lstatSync(filename);
 
       if (stat.isDirectory()) directories.push(filename);
-      else if (filename.indexOf(stringSearch) >= 0) foundFiles.push(filename);
+      else if (filename.indexOf(stringSearch) >= 0 && notGithubDirectory(filename)) foundFiles.push(filename);
     });
   }
 
   return foundFiles;
+};
+
+const notGithubDirectory = (filename) => {
+  return !filename.includes('.github/actions'); 
 };
 
 module.exports = findFilesBy;

--- a/findFilesBy.js
+++ b/findFilesBy.js
@@ -34,8 +34,6 @@ const findFilesBy = (startDirectory, stringSearch) => {
   return foundFiles;
 };
 
-const notGithubDirectory = (filename) => {
-  return !filename.includes('.github/actions'); 
-};
+const notGithubDirectory = (filename) => !filename.includes('.github/actions');
 
 module.exports = findFilesBy;


### PR DESCRIPTION
## Changelog
Desconsidera a pasta `.github/actions` porque o avaliador deve buscar somente o `.eslintrc` dentro da pasta do projeto a ser avaliado

Portanto, esta condicional remove arquivos que estarão dentro da action em si.