### PR TITLE
feat: Altera tipo da action para rodar com Node 18

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,17 @@ inputs:
     description: 'Pull Request number that dispatched the workflow'
     required: true
 runs:
-  using: "node16"
-  main: "dist/index.js"
+  using: "composite"
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: ESLint Evaluator
+      run: node ${{ github.action_path }}/dist/index.js
+      shell: bash
+      env:
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_IGNOREINLINECONFIG: ${{ inputs.ignoreInlineConfig }}
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
# O que está sendo implementado

- altera o tipo da action (de [javascript action](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action) para [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action))
- configura o ambiente para rodar em Node 18
-  cria o step `ESLint evaluator` para rodar o `script dist/index.js`

## PRs rodando essa versão em homologação
- [projeto iChoveu, com 100% dos requisitos](https://github.com/betrybe/sd-00-project-iChoveu-2023-08-24-20-38-22/pull/6)
- [projeto iChoveu, com 0% dos requisitos](https://github.com/betrybe/sd-00-project-iChoveu-2023-08-24-20-38-22/pull/4)
- [projeto iChouve com erro de ESLint](https://github.com/betrybe/sd-00-project-iChoveu-2023-08-24-20-38-22/pull/5)